### PR TITLE
Se corrigió un problema con los comentarios de una línea en archivos JS

### DIFF
--- a/FUSION.php
+++ b/FUSION.php
@@ -19,6 +19,7 @@ class FUSION {
                require $file;
             }
             $cont = ob_get_clean();
+            $cont = preg_replace('/(?<!\S)\/\/\s*[^\r\n]*/', '', $cont);
             $cont = preg_replace('!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $cont);
             $cont = str_replace(array("\r\n", "\r", "\n", "\t", '  ', '    ', '    '), '', $cont);
             file_put_contents($archivo, $cont);


### PR DESCRIPTION
Se corrige un bug en la extensión FUSION, que fusionaba los archivos JS con error al no eliminar los comentarios de una línea como // algo
